### PR TITLE
Integrate remote budget module

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -115,6 +115,12 @@ export default [
     component: './Currency',
   },
   {
+    path: '/budget',
+    name: 'budget',
+    icon: 'pie-chart',
+    component: './Budget',
+  },
+  {
     path: '/note-days',
     name: 'noteDays',
     component: './NoteDay',

--- a/src/locales/en-US/menu.ts
+++ b/src/locales/en-US/menu.ts
@@ -13,6 +13,7 @@ export default {
   'menu.categories': 'Book Config',
   'menu.groups': 'Groups',
   'menu.bookTemplates': 'Book Templates',
+  'menu.budget': 'Budget',
   'menu.noteDays': 'Note Days',
   'menu.trash': 'Recycle Bin',
   'menu.login': 'Login Page',

--- a/src/locales/zh-CN/menu.ts
+++ b/src/locales/zh-CN/menu.ts
@@ -13,6 +13,7 @@ export default {
   'menu.categories': '账本配置',
   'menu.bookTemplates': '账本模板',
   'menu.groups': '分组管理',
+  'menu.budget': '预算',
   'menu.noteDays': '提醒事项',
   'menu.trash': '回收站',
   'menu.login': '登录页',

--- a/src/pages/Budget/index.jsx
+++ b/src/pages/Budget/index.jsx
@@ -1,0 +1,13 @@
+import { PageContainer } from '@ant-design/pro-components';
+
+export default () => {
+  return (
+    <PageContainer title={false}>
+      <iframe
+        src="https://budget.mylabcdd.top:30046/"
+        style={{ width: '100%', height: '80vh', border: 'none' }}
+        title="Budget"
+      />
+    </PageContainer>
+  );
+};


### PR DESCRIPTION
## Summary
- integrate remote budget app with an iframe
- wire up `/budget` route
- localize menu item for budget

## Testing
- `npm run test:e2e` *(fails: Missing script: "playwright")*

------
https://chatgpt.com/codex/tasks/task_e_6889f86a45ac832fa789b045609cbdd2