### PR TITLE
feat: send token on logout

### DIFF
--- a/src/components/RightContent/AvatarDropdown.jsx
+++ b/src/components/RightContent/AvatarDropdown.jsx
@@ -15,10 +15,13 @@ const AvatarDropdown = () => {
 
   const onMenuClick = async ({ key }) => {
     if (key === 'logout') {
-      localStorage.removeItem('accessToken');
-      sessionStorage.removeItem('accessToken');
-      // await logout();
-      window.location.href = '/user/login';
+      try {
+        await logout();
+      } finally {
+        localStorage.removeItem('accessToken');
+        sessionStorage.removeItem('accessToken');
+        window.location.href = '/user/login';
+      }
     }
     if (key === 'changePassword') {
       show(<ChangePasswordForm />);

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -10,6 +10,9 @@ export async function login(data) {
 export async function logout() {
   return request('logout', {
     method: 'POST',
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('accessToken') ?? ''}`,
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- send token to backend on logout and clear stored token
- include Authorization header when calling logout service

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: react/jsx-no-target-blank etc.)

------
https://chatgpt.com/codex/tasks/task_e_68901f056ca0832f8fcbad91c7943732