### PR TITLE
feat: implement refresh token auto renewal

### DIFF
--- a/src/components/RightContent/AvatarDropdown.jsx
+++ b/src/components/RightContent/AvatarDropdown.jsx
@@ -20,6 +20,8 @@ const AvatarDropdown = () => {
       } finally {
         localStorage.removeItem('accessToken');
         sessionStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        sessionStorage.removeItem('refreshToken');
         window.location.href = '/user/login';
       }
     }

--- a/src/components/RightContent/ChangePasswordForm.jsx
+++ b/src/components/RightContent/ChangePasswordForm.jsx
@@ -10,6 +10,9 @@ export default () => {
 
   const successHandler = async () => {
     localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    sessionStorage.removeItem('accessToken');
+    sessionStorage.removeItem('refreshToken');
     setTimeout(function () {
       window.location.href = '/user/login';
     }, 500);

--- a/src/pages/BalanceFlow/FileUploadModal.jsx
+++ b/src/pages/BalanceFlow/FileUploadModal.jsx
@@ -26,7 +26,9 @@ export default ({ flowId }) => {
     listType: 'picture-card',
     action: `/api/v1/balance-flows/${flowId}/addFile`,
     headers: {
-      Authorization: `Bearer ${localStorage.getItem("accessToken") ?? ''}`,
+      get Authorization() {
+        return `Bearer ${localStorage.getItem("accessToken") ?? ''}`;
+      },
     },
     isImageUrl(file) {
       return file.isImage;

--- a/src/pages/User/Login/index.jsx
+++ b/src/pages/User/Login/index.jsx
@@ -17,6 +17,7 @@ export default () => {
   const handleSubmit = async (values) => {
     const response = await login({ ...values });
     localStorage.setItem('accessToken', response.data.accessToken);
+    localStorage.setItem('refreshToken', response.data.refreshToken);
     setTimeout(() => {
       window.location.href = '/';
     }, 300);
@@ -51,7 +52,14 @@ export default () => {
       windowRef.current.close();
     }
     if (formRef.current?.getFieldValue('remember')) {
-      localStorage.setItem('accessToken', e.data);
+      if (typeof e.data === 'string') {
+        localStorage.setItem('accessToken', e.data);
+      } else {
+        localStorage.setItem('accessToken', e.data.accessToken);
+        if (e.data.refreshToken) {
+          localStorage.setItem('refreshToken', e.data.refreshToken);
+        }
+      }
     }
     window.location.href = '/report';
   }

--- a/src/requestErrorConfig.js
+++ b/src/requestErrorConfig.js
@@ -1,5 +1,45 @@
-﻿import { message } from 'antd';
+import { message } from 'antd';
 import qs from 'qs';
+import { request as umiRequest } from '@umijs/max';
+
+let refreshPromise = null;
+
+const parseJwt = (token) => {
+  try {
+    const base64 = token.split('.')[1];
+    const json = typeof window === 'undefined'
+      ? Buffer.from(base64, 'base64').toString('utf8')
+      : atob(base64);
+    return JSON.parse(json);
+  } catch {
+    return {};
+  }
+};
+
+const refreshAccessToken = async () => {
+  if (!refreshPromise) {
+    const refreshToken = localStorage.getItem('refreshToken');
+    if (!refreshToken) {
+      throw new Error('no refresh token');
+    }
+    refreshPromise = umiRequest('refresh', {
+      method: 'POST',
+      data: { refreshToken },
+      skipErrorHandler: true,
+    })
+      .then((res) => {
+        localStorage.setItem('accessToken', res.data.accessToken);
+        if (res.data.refreshToken) {
+          localStorage.setItem('refreshToken', res.data.refreshToken);
+        }
+        return res.data.accessToken;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+  return refreshPromise;
+};
 
 /**
  * @name 错误处理
@@ -12,19 +52,54 @@ export const errorConfig = {
   headers: {
     'Content-Type': 'application/json',
     'Accept-Language': localStorage.getItem("umi_locale") ?? 'zh-CN',
-    'Authorization': `Bearer ${localStorage.getItem("accessToken") ?? ''}`,
   },
   paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'repeat' }),
+  requestInterceptors: [
+    async (config) => {
+      if ((config.url || '').includes('refresh')) {
+        return config;
+      }
+      let token = localStorage.getItem('accessToken');
+      if (token) {
+        const { exp } = parseJwt(token);
+        if (exp && exp * 1000 - Date.now() < 60 * 1000) {
+          try {
+            token = await refreshAccessToken();
+          } catch (e) {
+            localStorage.removeItem('accessToken');
+            sessionStorage.removeItem('accessToken');
+            localStorage.removeItem('refreshToken');
+            sessionStorage.removeItem('refreshToken');
+            window.location.href = '/user/login';
+          }
+        }
+        config.headers = config.headers || {};
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    },
+  ],
   errorConfig: {
     // 错误接收及处理
-    errorHandler: (error, opts) => {
+    errorHandler: async (error, opts) => {
       if (opts?.skipErrorHandler) throw error;
       if (error?.response?.status === 401 && window.location.pathname !== '/user/login') {
-        message.error('登录已过期，请重新登录');
-        localStorage.removeItem('accessToken');
-        sessionStorage.removeItem('accessToken');
-        window.location.href = '/user/login';
-        return;
+        try {
+          const token = await refreshAccessToken();
+          const config = error.config || {};
+          config.headers = config.headers || {};
+          config.headers.Authorization = `Bearer ${token}`;
+          const url = (config.url || '').replace(config.baseURL || '', '');
+          return umiRequest(url, { ...config, skipErrorHandler: true });
+        } catch (e) {
+          message.error('登录已过期，请重新登录');
+          localStorage.removeItem('accessToken');
+          sessionStorage.removeItem('accessToken');
+          localStorage.removeItem('refreshToken');
+          sessionStorage.removeItem('refreshToken');
+          window.location.href = '/user/login';
+          return;
+        }
       }
       console.log(error);
       // if (error.response.data?.message) {

--- a/src/services/user.js
+++ b/src/services/user.js
@@ -10,9 +10,14 @@ export async function login(data) {
 export async function logout() {
   return request('logout', {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('accessToken') ?? ''}`,
-    },
+  });
+}
+
+export async function refresh(data) {
+  return request('refresh', {
+    method: 'POST',
+    data: data,
+    skipErrorHandler: true,
   });
 }
 


### PR DESCRIPTION
## Summary
- add refresh token service and automatic renewal
- store both access and refresh tokens on login
- clear tokens on logout and password change

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 2 errors, 73 warnings)


------
https://chatgpt.com/codex/tasks/task_e_6890a5ff9624832fbce5ba95aa678bf5