### PR TITLE
feat: refresh token with auth header

### DIFF
--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -21,7 +21,7 @@ export default () => {
       {/*  <span>{t('footer.qq.group')}: 639653091</span>*/}
       {/*</div>*/}
       <div>
-        &copy; {new Date().getFullYear()} <a href="https://www.moneynote.com" target="_blank">moneynote.com</a>
+        &copy; {new Date().getFullYear()} <a href="https://www.moneynote.com" target="_blank" rel="noreferrer">moneynote.com</a>
         <Divider type="vertical" />
         v{packageJson.version}
         <Divider type="vertical" />

--- a/src/global.jsx
+++ b/src/global.jsx
@@ -2,6 +2,7 @@ import { useIntl } from '@umijs/max';
 import { Button, message, notification } from 'antd';
 import defaultSettings from '../config/defaultSettings';
 import * as Sentry from "@sentry/react";
+import { refreshAccessToken } from './requestErrorConfig';
 
 const { pwa } = defaultSettings;
 const isHttps = document.location.protocol === 'https:';
@@ -106,3 +107,13 @@ window.addEventListener("unhandledrejection", function(e){
   console.log('捕获到异常：', e);
   return true;
 });
+
+setInterval(() => {
+  const refreshToken = localStorage.getItem('refreshToken');
+  const accessToken = localStorage.getItem('accessToken');
+  if (refreshToken && accessToken) {
+    refreshAccessToken().catch((e) => {
+      console.log('failed to refresh token', e);
+    });
+  }
+}, 60 * 1000);

--- a/src/pages/BookTemplates/DataTable.jsx
+++ b/src/pages/BookTemplates/DataTable.jsx
@@ -22,7 +22,11 @@ export default () => {
     {
       title: t('template.label.previewUrl'),
       dataIndex: 'previewUrl',
-      render: (_, record) => <a href={record.previewUrl} target="_blank">{t('template.label.preview.click')}</a>,
+      render: (_, record) => (
+        <a href={record.previewUrl} target="_blank" rel="noreferrer">
+          {t('template.label.preview.click')}
+        </a>
+      ),
       hideInSearch: true,
     },
     {

--- a/src/requestErrorConfig.js
+++ b/src/requestErrorConfig.js
@@ -4,7 +4,7 @@ import { request as umiRequest } from '@umijs/max';
 
 let refreshPromise = null;
 
-const parseJwt = (token) => {
+export const parseJwt = (token) => {
   try {
     const base64 = token.split('.')[1];
     const json = typeof window === 'undefined'
@@ -16,14 +16,18 @@ const parseJwt = (token) => {
   }
 };
 
-const refreshAccessToken = async () => {
+export const refreshAccessToken = async () => {
   if (!refreshPromise) {
     const refreshToken = localStorage.getItem('refreshToken');
-    if (!refreshToken) {
-      throw new Error('no refresh token');
+    const accessToken = localStorage.getItem('accessToken');
+    if (!refreshToken || !accessToken) {
+      throw new Error('no refresh or access token');
     }
     refreshPromise = umiRequest('refresh', {
       method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
       data: { refreshToken },
       skipErrorHandler: true,
     })


### PR DESCRIPTION
## Summary
- attach current access token when calling refresh endpoint
- refresh access token every minute while tokens exist
- add rel="noreferrer" to external links to satisfy lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint:js` *(73 warnings)*
- `npm run tsc`
- `npx prettier -c "src/**/*"` *(fails: Code style issues found in 129 files)*

------
https://chatgpt.com/codex/tasks/task_e_6890d7522998832fb3f7a3553ac4f917