### PR TITLE
refactor: rely on interceptors for token refresh

### DIFF
--- a/src/global.jsx
+++ b/src/global.jsx
@@ -107,13 +107,3 @@ window.addEventListener("unhandledrejection", function(e){
   console.log('捕获到异常：', e);
   return true;
 });
-
-setInterval(() => {
-  const refreshToken = localStorage.getItem('refreshToken');
-  const accessToken = localStorage.getItem('accessToken');
-  if (refreshToken && accessToken) {
-    refreshAccessToken().catch((e) => {
-      console.log('failed to refresh token', e);
-    });
-  }
-}, 60 * 1000);


### PR DESCRIPTION
## Summary
- remove periodic refresh loop to rely on interceptor and 401 handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint:js`
- `npm run tsc` *(no tsconfig, shows help)*

------
https://chatgpt.com/codex/tasks/task_e_6891aef096c0832fb1a2ba12bac64efe