### PR TITLE
feat(login): store tokens in session storage

### DIFF
--- a/src/pages/User/Login/index.jsx
+++ b/src/pages/User/Login/index.jsx
@@ -18,6 +18,8 @@ export default () => {
     const response = await login({ ...values });
     localStorage.setItem('accessToken', response.data.accessToken);
     localStorage.setItem('refreshToken', response.data.refreshToken);
+    sessionStorage.setItem('accessToken', response.data.accessToken);
+    sessionStorage.setItem('refreshToken', response.data.refreshToken);
     setTimeout(() => {
       window.location.href = '/';
     }, 300);
@@ -54,10 +56,13 @@ export default () => {
     if (formRef.current?.getFieldValue('remember')) {
       if (typeof e.data === 'string') {
         localStorage.setItem('accessToken', e.data);
+        sessionStorage.setItem('accessToken', e.data);
       } else {
         localStorage.setItem('accessToken', e.data.accessToken);
+        sessionStorage.setItem('accessToken', e.data.accessToken);
         if (e.data.refreshToken) {
           localStorage.setItem('refreshToken', e.data.refreshToken);
+          sessionStorage.setItem('refreshToken', e.data.refreshToken);
         }
       }
     }


### PR DESCRIPTION
## Summary
- write access and refresh tokens to sessionStorage alongside localStorage during login

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891aeef3b9c832f85f436ca25291547